### PR TITLE
reorganization of classes and modules

### DIFF
--- a/src/components/class_content_list.js
+++ b/src/components/class_content_list.js
@@ -28,9 +28,7 @@ class ClassContentList extends React.Component {
           <div>
             <h4>Constructors</h4>
             <ul>
-              {PrintList(
-                this.props.value.structure.constructors,
-                "constructors"
+              {PrintList(this.props.value.structure.constructors, "constructors"
               )}
             </ul>
           </div>
@@ -41,16 +39,22 @@ class ClassContentList extends React.Component {
             <ul>{PrintList(this.props.value.structure.statics, "statics")}</ul>
           </div>
         )}
-        {this.props.value.structure.fields.length > 0 && (
+        {this.props.value.structure.factories.length > 0 && (
           <div>
-            <h4>Fields</h4>
-            <ul>{PrintList(this.props.value.structure.fields, "fields")}</ul>
+            <h4>Factories</h4>
+            <ul>{PrintList(this.props.value.structure.factories, "factories")}</ul>
           </div>
         )}
         {this.props.value.structure.methods.length > 0 && (
           <div>
             <h4>Methods</h4>
             <ul>{PrintList(this.props.value.structure.methods, "methods")}</ul>
+          </div>
+        )}
+        {this.props.value.structure.fields.length > 0 && (
+          <div>
+            <h4>Fields</h4>
+            <ul>{PrintList(this.props.value.structure.fields, "fields")}</ul>
           </div>
         )}
       </div>

--- a/src/components/class_info.js
+++ b/src/components/class_info.js
@@ -24,7 +24,7 @@ function Extends({ reference }) {
 function Constructors(props) {
   return (
     <div>
-      <Typography variant="h2" component="h2">
+      <Typography variant="h3" component="h3">
         Constructors
       </Typography>
       <Methods
@@ -41,7 +41,7 @@ function Constructors(props) {
 function Statics(props) {
   return (
     <div>
-      <Typography variant="h2" component="h2">
+      <Typography variant="h3" component="h3">
         Statics
       </Typography>
       <Methods
@@ -58,7 +58,7 @@ function Statics(props) {
 function Factories(props) {
   return (
     <div>
-      <Typography variant="h2" component="h2">
+      <Typography variant="h3" component="h3">
         Factories
       </Typography>
       <Methods
@@ -67,6 +67,23 @@ function Factories(props) {
         moduleName={props.moduleName}
         className={props.className}
         functionType="Factories"
+      />
+    </div>
+  );
+}
+
+function ClassMethods(props) {
+  return (
+    <div>
+      <Typography variant="h3" component="h3">
+        Methods
+      </Typography>
+      <Methods
+        value={props.value}
+        libName={props.libName}
+        moduleName={props.moduleName}
+        className={props.className}
+        functionType="Methods"
       />
     </div>
   );
@@ -103,23 +120,6 @@ const style = (theme) => ({
   },
 });
 
-function ClassMethods(props) {
-  return (
-    <div>
-      <Typography variant="h3" component="h2">
-        Methods
-      </Typography>
-      <Methods
-        value={props.value}
-        libName={props.libName}
-        moduleName={props.moduleName}
-        className={props.className}
-        functionType="Methods"
-      />
-    </div>
-  );
-}
-
 function mapStateToProps(state, props) {
   const { sdk } = state;
   return {
@@ -135,7 +135,7 @@ class ClassInfo extends Component {
     return (
       <Grid container>
         <Grid item xs={12} sm={9}>
-          <Typography variant="h1" component="h1">
+          <Typography variant="h2" component="h2">
             Class: {name} not found!
           </Typography>
         </Grid>
@@ -170,7 +170,7 @@ class ClassInfo extends Component {
         <Grid container>
           <Grid item xs={12} sm={9}>
             <Box pt={2} pb={2}>
-              <Typography variant="h1" component="h1">
+              <Typography variant="h2" component="h2">
                 Class: {class_info.name}
               </Typography>
               {class_info.extends && <Extends reference={class_info.extends} />}
@@ -199,13 +199,20 @@ class ClassInfo extends Component {
                 functionType="Statics"
               />
             )}
-            <Fields fields={class_info.structure.fields} />
             {class_info.structure.methods.length > 0 && (<ClassMethods
                 value={class_info.structure.methods}
                 libName={libName}
                 moduleName={moduleName}
                 className={className}
                 functionType="Methods"
+              />
+            )}
+            {class_info.structure.fields.length > 0 && (<Fields
+                fields={class_info.structure.fields}
+                libName={libName}
+                moduleName={moduleName}
+                className={className}
+                functionType="Fields"
               />
             )}
           </Grid>

--- a/src/components/class_nav.js
+++ b/src/components/class_nav.js
@@ -43,8 +43,7 @@ class ClassNav extends Component {
                 <ListSubheader component="div" id="nested-list-subheader">
                   <Link to={`/`}>Modules /</Link>
                   <Typography color="secondary">
-                    <Link to={`/${libName}/${moduleName}`}>{moduleName}</Link>
-                    {" / "}
+                    <Link to={`/${libName}/${moduleName}`}>{moduleName}</Link> {" / "}
                     <h1><p></p></h1>
                     {className}
                   </Typography>

--- a/src/components/module_content_list.js
+++ b/src/components/module_content_list.js
@@ -36,22 +36,23 @@ class ModuleContentList extends React.Component {
   render() {
     return (
       <div>
+
         <h4>Classes</h4>
         {List(this.props.value.classes, "classes")}
 
-        <h4>Exported Classes</h4>
+        <h4>Exported classes</h4>
         {List(this.props.value.export_classes, "export_classes")}
 
-        <h4>Variables</h4>
+        <h4>Globals</h4>
         {List(this.props.value.globals, "globals")}
+
+        <h4>Exported globals</h4>
+        {List(this.props.value.export_globals, "export_globals")}
 
         <h4>Function</h4>
         {List(this.props.value.functions, "functions")}
 
-        <h4>Export variables</h4>
-        {List(this.props.value.export_globals, "export_globals")}
-
-        <h4>Export function</h4>
+        <h4>Exported functions</h4>
         {List(this.props.value.export_functions, "export_functions")}
       </div>
     );

--- a/src/components/module_info.js
+++ b/src/components/module_info.js
@@ -23,9 +23,13 @@ const style = (theme) => ({
 function Globals(props) {
   return (
     <div>
-      <Typography component="h3" variant="h3">
-        Variables
-      </Typography>
+      <Box pt={2} pb={2}>
+        <Box pt={1} pb={1}>
+          <Typography component="h3" variant="h3">
+            Globals
+          </Typography>
+        </Box> 
+     </Box> 
       {[]
         .concat(props.globals)
         .sort((a, b) => a.name.localeCompare(b.name))
@@ -43,13 +47,46 @@ function Globals(props) {
 function GlobalFunctions(props) {
     return (
       <div>
-        <Typography component="h3" variant="h3">
-          Functions
-        </Typography>
+        <Box pt={2} pb={2}>
+          <Box pt={1} pb={1}>
+            <Typography component="h3" variant="h3">
+              Functions
+            </Typography>
+          </Box> 
+       </Box> 
         <FunctionsInModules functions={props.functions} />
       </div>
     );
 }
+
+function ExportFunctions(props) {
+  return (
+    <div>
+      <Box pt={2} pb={2}>
+        <Box pt={1} pb={1}>
+          <Typography component="h3" variant="h3">
+            Exported Functions
+          </Typography>
+        </Box> 
+     </Box> 
+    </div>
+  );
+}
+
+function ExportGlobals(props) {
+  return (
+    <div>
+      <Box pt={2} pb={2}>
+        <Box pt={1} pb={1}>
+          <Typography component="h3" variant="h3">
+            Exported Globals
+          </Typography>
+        </Box> 
+     </Box> 
+    </div>
+  );
+}
+
 
 function importPath(library, module) {
   const filename = module.name.substring(0, module.name.lastIndexOf("."));
@@ -82,7 +119,7 @@ function PrintClasses(props) {
             <Link
               to={`/${props.libName}/${props.moduleName}/${elem.name}`}
             >
-              <Typography component="h3" variant="h4">
+              <Typography component="h4" variant="h4">
                 {elem.name}{" "}
               </Typography>
             </Link>
@@ -107,7 +144,7 @@ class ModuleInfo extends Component {
           <Grid container className={classes.root}>
             <Grid item xs={9}>
               <Box pt={2} pb={2}>
-                <Typography component="h1" variant="h1">
+                <Typography component="h2" variant="h2">
                   module: {module.name}
                 </Typography>
               </Box>
@@ -123,7 +160,7 @@ class ModuleInfo extends Component {
               {module.classes.length > 0 &&
                 <Box pt={2} pb={2}>
                   <Box pt={1} pb={1}>
-                    <Typography component="h2" variant="h2">
+                    <Typography component="h3" variant="h3">
                       Classes
                     </Typography>
                   </Box>
@@ -137,7 +174,7 @@ class ModuleInfo extends Component {
               {module.export_classes.length > 0 &&
                 <Box pt={2} pb={2}>
                   <Box pt={1} pb={1}>
-                    <Typography component="h2" variant="h2">
+                    <Typography component="h3" variant="h3">
                       Exported classes
                     </Typography>
                   </Box>
@@ -148,13 +185,18 @@ class ModuleInfo extends Component {
                   />
                 </Box>
               }
-              <Globals globals={module.globals} />
-              <GlobalFunctions functions={module.functions} />
-              <Typography component="h2" variant="h2">
-                Exports
-              </Typography>
-              <Globals globals={module.export_globals} />
-              <GlobalFunctions functions={module.export_functions} />
+              {module.globals.length > 0 &&
+                <Globals globals={module.globals}/>
+              }
+              {module.export_globals.length > 0 &&
+                <ExportGlobals ExportGlobals={module.export_globals}/>
+              }
+              {module.functions.length > 0 &&
+                <GlobalFunctions functions={module.functions} />
+              }
+              {module.export_functions.length > 0 &&
+                <ExportFunctions ExportFunctions={module.export_functions}/>
+              }
             </Grid>
             <Hidden xsDown>
               <Grid item xs={3}>
@@ -169,7 +211,7 @@ class ModuleInfo extends Component {
         <Grid containerclassName={this.props.classes.root}>
           <Grid item xs={9}>
             <Box pt={2} pb={2}>
-              <Typography component="h1" variant="h1">
+              <Typography component="h2" variant="h2">
                 ERROR:
                 <p>Module not found</p>
               </Typography>


### PR DESCRIPTION
titles are the same size for all elements in classes and modules. They only show if there is at least one item for a category in the main window.
In the right hand side window, we have a different behavior for modules than for classes. In modules, all the elements always show, even when empty, but in classes, only the elements with items in the list will show. I see the difference in code between module_content_list and class_content_list but I cannot fix it.