### PR TITLE
Scroll to top on route change

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import ScrollableContainer from "./components/general/ScrollableContainer";
 import { HEADER_BAR_HEIGHT } from "./components/HeaderBarView";
 import { ModuleInfoParams } from "./components/ModuleInfoView";
 import { NavigationParams } from "./components/NavigationView";
+import ScrollToTop from "./components/ScrollToTop";
 import WelcomePage from "./components/WelcomePage";
 import ClassInfo from "./containers/ClassInfo";
 import HeaderBar from "./containers/HeaderBar";
@@ -75,6 +76,7 @@ class App extends Component<AppProps> {
     return (
       <ThemeProvider theme={theme}>
         <BrowserRouter>
+          <ScrollToTop />
           {this.props.object !== undefined ? (
             <>
               <ErrorBoundary>

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop(): null {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    document.getElementById("scrollablecontainer")?.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/general/ScrollableContainer.tsx
+++ b/src/components/general/ScrollableContainer.tsx
@@ -28,7 +28,10 @@ class ScrollableContainer extends React.Component<ScrollableContainerProps> {
   render(): JSX.Element {
     return (
       <div className={this.props.classes.container}>
-        <div className={this.props.classes.containerInner}>
+        <div
+          className={this.props.classes.containerInner}
+          id="scrollablecontainer"
+        >
           {this.props.children}
         </div>
       </div>


### PR DESCRIPTION
Whenever the URL changes, the page is now scrolled to the top (unless following a hash link)