### PR TITLE
Fix links to bar/bar.toit elements.

### DIFF
--- a/src/generator/convert.ts
+++ b/src/generator/convert.ts
@@ -74,10 +74,10 @@ function pathFrom(path: string[]): string[] {
   const result = path.slice();
   result.shift(); // Get rid of first "lib" entry. TODO (rikke): Find a more general rule.
   const len = result.length;
-  if (len == 0) return result;
+  if (len === 0) return result;
   result[len - 1] = libraryName(result[len - 1]);
-  if (len == 1) return result;
-  if (result[len - 1] == result[len - 2]) {
+  if (len === 1) return result;
+  if (result[len - 1] === result[len - 2]) {
     // Something like lib/net/net.toit.
     // In that case the net.toit is presented as 'lib.net' (as this is how it would
     // be imported).


### PR DESCRIPTION
The toitdoc viewer presents 'bar/bar.toit' as 'bar' (as this is how it
would be imported). We need to fix links to these files.

As an example look at the 'net' library and the link of the return type
'Interface' for the return-type of the `open` function.