### PR TITLE
Fix overlapping code blocks

### DIFF
--- a/src/components/general/CodeBlock.tsx
+++ b/src/components/general/CodeBlock.tsx
@@ -6,7 +6,6 @@ import "../../assets/codemirror/codemirror.css";
 import "../../assets/codemirror/toit";
 
 const Wrapper = styled.div`
-  max-height: 400px;
   .CodeMirror {
     background: #b0b8ed20;
     padding: 1rem;


### PR DESCRIPTION
The were two options to solve this:

1. remove the `maxHeight`
2. make the code container scrollable

I went with 1. because I feel it's more comfortable to work with.

Fixes toitware/web-docs#321