### PR TITLE
Don't create separate analytic event types for different pages

### DIFF
--- a/src/components/main/ClassInfoView.tsx
+++ b/src/components/main/ClassInfoView.tsx
@@ -25,7 +25,7 @@ export default class ClassInfoView extends Component<ClassInfoProps> {
     const hashId = this.props.location.hash.substring(1);
     const element = document.getElementById(hashId);
     element?.scrollIntoView(true);
-    analytics.page(this.props.location.pathname);
+    analytics.page("toitdocs");
   }
 
   render(): React.ReactNode {

--- a/src/components/main/LibraryInfoView.tsx
+++ b/src/components/main/LibraryInfoView.tsx
@@ -47,7 +47,7 @@ class LibraryInfoView extends Component<LibraryInfoProps> {
     const hashId = this.props.location.hash.substring(1);
     const element = document.getElementById(hashId);
     element?.scrollIntoView(true);
-    analytics.page(this.props.location.pathname);
+    analytics.page("toitdocs");
   }
 
   render(): JSX.Element {

--- a/src/components/navigation/NavigationView.tsx
+++ b/src/components/navigation/NavigationView.tsx
@@ -40,7 +40,7 @@ const NavigationView: React.FC<NavigationProps> = ({
   match,
   className,
 }: NavigationProps) => {
-  analytics.page(location.pathname);
+  analytics.page("toitdocs");
 
   const libraries = useSelector<RootState, Libraries>(
     (state) => state.doc.libraries || {}


### PR DESCRIPTION
The call to analytics.page was incorrect. The first (optional) argument is the event category. The path is automatically included.