### PR TITLE
Move 'disable jekyll' closer to the gh-pages action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,10 +171,6 @@ jobs:
           name: build
           path: build
 
-      - name: Disable Jekyll
-        run: |
-          touch build/.nojekyll
-
       - name: Untar
         run: |
           cd build
@@ -194,6 +190,10 @@ jobs:
           echo "Fetching Toit documentation from $URL"
           mkdir -p build/sdk
           curl -L $URL -o build/sdk/latest.json
+
+      - name: Disable Jekyll
+        run: |
+          touch build/.nojekyll
 
       # This seems to be the simplest way to publish to a separate branch.
       - name: Deploy


### PR DESCRIPTION
This makes it less likely that we only copy the Deploy step into other workflows.