### PR TITLE
Improve header for packages and sdk branch.

### DIFF
--- a/src/components/main/LibraryInfoView.tsx
+++ b/src/components/main/LibraryInfoView.tsx
@@ -65,8 +65,8 @@ class LibraryInfoView extends Component<LibraryInfoProps> {
     let isAbsoluteSDK = false;
     let isPackage = false;
 
-    isAbsoluteSDK = libName == "@" || libName.startsWith("@");
-    isPackage = libName == ".packages" || libName.startsWith(".packages/");
+    isAbsoluteSDK = libName === "@" || libName.startsWith("@");
+    isPackage = libName === ".packages" || libName.startsWith(".packages/");
     console.log("libName", libName);
 
     switch (viewMode) {

--- a/src/components/main/LibraryInfoView.tsx
+++ b/src/components/main/LibraryInfoView.tsx
@@ -67,7 +67,6 @@ class LibraryInfoView extends Component<LibraryInfoProps> {
 
     isAbsoluteSDK = libName === "@" || libName.startsWith("@");
     isPackage = libName === ".packages" || libName.startsWith(".packages/");
-    console.log("libName", libName);
 
     switch (viewMode) {
       case ViewMode.SDK:

--- a/src/components/main/LibraryInfoView.tsx
+++ b/src/components/main/LibraryInfoView.tsx
@@ -60,9 +60,14 @@ class LibraryInfoView extends Component<LibraryInfoProps> {
 
     const importPath = libName.replace(/\//g, ".");
     let isCoreExported = false;
-    let noImport = false;
     let isCore = false;
     let showImportHelp = true;
+    let isAbsoluteSDK = false;
+    let isPackage = false;
+
+    isAbsoluteSDK = libName == "@" || libName.startsWith("@");
+    isPackage = libName == ".packages" || libName.startsWith(".packages/");
+    console.log("libName", libName);
 
     switch (viewMode) {
       case ViewMode.SDK:
@@ -72,7 +77,6 @@ class LibraryInfoView extends Component<LibraryInfoProps> {
           isCoreExported = false;
         }
         isCore = libName === "core";
-        noImport = isCoreExported || isCore;
         break;
       case ViewMode.Package:
         // Do nothing.
@@ -91,12 +95,16 @@ class LibraryInfoView extends Component<LibraryInfoProps> {
         </div>
         {showImportHelp && (
           <div className={this.props.classes.importingText}>
-            {noImport ? (
+            {isCore || isCoreExported ? (
               <Typography>
                 This is {isCoreExported ? "exported from" : ""} the core
                 library, which means you {isCore ? "usually" : ""} don&#39;t
                 need to import it.
               </Typography>
+            ) : isAbsoluteSDK ? (
+              <Typography>This is the SDK branch.</Typography>
+            ) : isPackage ? (
+              <Typography>This is an imported packages branch.</Typography>
             ) : (
               <div>
                 <Typography>To use this library in your code:</Typography>


### PR DESCRIPTION
When running `toit doc serve --package path-to-package` we show the SDK under a '@' branch and imported packages in a `.packages`.

We used to have `To use this library ...` headers for this libraries. Now we just state that these are special.